### PR TITLE
Made it an option to strip out html

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -94,7 +94,8 @@ function secondary_title_get_default_settings(): array {
 		"secondary_title_feed_auto_show"         => "off",
 		"secondary_title_feed_title_format"      => "%title%",
 		"secondary_title_include_in_search"      => "on",
-		"secondary_title_show_donation_notice"   => "on"
+		"secondary_title_show_donation_notice"   => "on",
+		"secondary_title_strip_html"             => "on"
 	];
 
 	$default_settings = apply_filters( "secondary_title_get_default_settings", $default_settings );

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -118,11 +118,15 @@ function secondary_title_edit_post( $post_id ) {
 		return false;
 	}
 
+	$secondary_post_title = filter_input( INPUT_POST, 'secondary_post_title' );
+	if (secondary_title_get_setting('strip_html') == 'on') {
+		$secondary_post_title = wp_strip_all_tags($secondary_post_title);	
+	}
 
 	return update_post_meta(
 		$post_id,
 		"_secondary_title",
-		esc_html( $antiXss->xss_clean( wp_strip_all_tags( filter_input( INPUT_POST, 'secondary_post_title' ) ) ) )
+		esc_html( $antiXss->xss_clean( $secondary_post_title ) )
 	);
 }
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -405,6 +405,36 @@ function secondary_title_settings_page() {
 								<?php if ( version_compare( $wp_version, "5.0", ">=" ) && class_exists( "Classic_Editor" ) ) { ?>
 									<tr>
 										<th>
+											<label for="strip-html-on">
+												<i class="fa fa-filter"></i>
+									<?php _e( "Strip HTML", "secondary-title" ); ?>:
+											</label>
+										</th>
+										<td>
+											<?php secondary_title_print_html_info_circle( "strip_html" ); ?>
+											<div class="radios">
+												<input type="radio"
+													name="strip_html"
+													id="strip-html-on"
+													value="on" <?php checked( $settings["strip_html"], "on" ); ?>>
+												<label for="strip-html-on">
+										<?php _e( "On", "secondary-title" ); ?>
+												</label>
+												<input type="radio"
+													name="strip_html"
+													id="strip-html-off"
+													value="off" <?php checked( $settings["strip_html"], "off" ); ?>>
+												<label for="strip-html-off">
+										<?php _e( "Off", "secondary-title" ); ?>
+												</label>
+											</div>
+											<p class="description">
+												<?php _e( "Strips all HTML from your secondary title. Removes a possible attack vector.", "secondary-title" ); ?>
+											</p>
+										</td>
+									</tr>
+									<tr>
+										<th>
 											 <label for="input-field-position-top">
 												 <i class="fa fa-arrow-up"></i>
 									  <?php _e( "Input field", "secondary-title" ); ?>:


### PR DESCRIPTION
I saw your XSS fix and it's great you still support the plugin but it went a little too far with automatically stripping out all of the HTML. The sites I work for need HTML in their secondary titles. But, I thought I'd make it an option, so people who want it (and want to take the risk) can allow it.